### PR TITLE
Split Logic in different Script, Re-Add files with to reflect Chris's Repo

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2253,6 +2253,19 @@
       "
     ]
   },
+  "WPFTweaksPowershell7": {
+    "Content": "Replace Default Powershell 5 to Powershell 7",
+    "Description": "This will edit the config file of the Windows Terminal Replacing the Powershell 5 to Powershell 7 and install Powershell 7 if necessary",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a007_",
+    "InvokeScript": [
+      "Invoke-WPFTweakPS7 -action \"PS7\""
+    ],
+    "UndoScript": [
+      "Invoke-WPFTweakPS7 -action \"PS5\""
+    ]
+  },
   "WPFTweaksOO": {
     "Content": "Run OO Shutup",
     "Description": "Runs OO Shutup and applies the recommended Tweaks. https://www.oo-software.com/en/shutup10",

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -12,6 +12,7 @@ Function Install-WinUtilProgramWinget {
     
     .NOTES
     The triple quotes are required any time you need a " in a normal script block.
+    The winget Return codes are documented here: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
     #>
     
     param(

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -12,7 +12,6 @@ Function Install-WinUtilProgramWinget {
     
     .NOTES
     The triple quotes are required any time you need a " in a normal script block.
-    The winget Return codes are documented here: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
     #>
     
     param(
@@ -36,30 +35,22 @@ Function Install-WinUtilProgramWinget {
             # This is up to the individual package maintainers to enable these options. Aka. not as clean as Linux Package Managers.
             Write-Host "Starting install of $($Program.winget) with winget."
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully."
                     continue
                 }
-                if ($status -eq  -1978335189){
-                    Write-Host "$($Program.winget) No applicable update found"
-                    continue
-                }
                 Write-Host "Attempt with User scope"
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User scope."
-                    continue
-                }
-                if ($status -eq  -1978335189){
-                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
                 Write-Host "Attempt with User prompt"
                 $userChoice = [System.Windows.MessageBox]::Show("Do you want to attempt $($Program.winget) installation with specific user credentials? Select 'Yes' to proceed or 'No' to skip.", "User Credential Prompt", [System.Windows.MessageBoxButton]::YesNo)
                 if ($userChoice -eq 'Yes') {
                     $getcreds = Get-Credential
-                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru -NoNewWindow
+                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru
                     Wait-Process -Id $process.Id
                     $status = $process.ExitCode
                 } else {
@@ -67,10 +58,6 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User prompt."
-                    continue
-                }
-                if ($status -eq  -1978335189){
-                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
             } catch {
@@ -81,7 +68,7 @@ Function Install-WinUtilProgramWinget {
         if($manage -eq "Uninstalling"){
             # Uninstall package via ID using winget directly.
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru -NoNewWindow).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru).ExitCode
                 if($status -ne 0){
                     Write-Host "Failed to uninstall $($Program.winget)."
                 } else {

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -35,22 +35,30 @@ Function Install-WinUtilProgramWinget {
             # This is up to the individual package maintainers to enable these options. Aka. not as clean as Linux Package Managers.
             Write-Host "Starting install of $($Program.winget) with winget."
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully."
                     continue
                 }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
+                    continue
+                }
                 Write-Host "Attempt with User scope"
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User scope."
+                    continue
+                }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
                 Write-Host "Attempt with User prompt"
                 $userChoice = [System.Windows.MessageBox]::Show("Do you want to attempt $($Program.winget) installation with specific user credentials? Select 'Yes' to proceed or 'No' to skip.", "User Credential Prompt", [System.Windows.MessageBoxButton]::YesNo)
                 if ($userChoice -eq 'Yes') {
                     $getcreds = Get-Credential
-                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru
+                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru -NoNewWindow
                     Wait-Process -Id $process.Id
                     $status = $process.ExitCode
                 } else {
@@ -58,6 +66,10 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User prompt."
+                    continue
+                }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
             } catch {
@@ -68,7 +80,7 @@ Function Install-WinUtilProgramWinget {
         if($manage -eq "Uninstalling"){
             # Uninstall package via ID using winget directly.
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -ne 0){
                     Write-Host "Failed to uninstall $($Program.winget)."
                 } else {

--- a/functions/public/Invoke-WPFTweakPS7.ps1
+++ b/functions/public/Invoke-WPFTweakPS7.ps1
@@ -1,0 +1,46 @@
+function Invoke-WPFTweakPS7{
+        <#
+    .SYNOPSIS
+        This will edit the config file of the Windows Terminal Replacing the Powershell 5 to Powershell 7 and install Powershell 7 if necessary
+    .PARAMETER action
+        PS7:           Configures Powershell 7 to be the default Terminal
+        PS5:           Configures Powershell 5 to be the default Terminal
+    #>
+    param (
+        [ValidateSet("PS7", "PS5")]
+        [string]$action
+    )
+
+    switch ($action) {
+        "PS7"{ 
+            if (Test-Path -Path "$env:ProgramFiles\PowerShell\7") {
+                Write-Host "Powershell 7 is already installed."
+            } else {
+                Write-Host "Installing Powershell 7..."
+                Install-WinUtilProgramWinget -ProgramsToInstall @(@{"winget"="Microsoft.PowerShell"})
+            }
+            $targetTerminalName = "PowerShell"
+        }
+        "PS5"{
+            $targetTerminalName = "Windows PowerShell"
+        }
+    }
+
+    $settingsPath = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
+    if (Test-Path -Path $settingsPath) {
+        Write-Host "Settings file found."
+        $settingsContent = Get-Content -Path $settingsPath | ConvertFrom-Json
+        $ps7Profile = $settingsContent.profiles.list | Where-Object { $_.name -eq $targetTerminalName }
+        if ($ps7Profile) {
+            $settingsContent.defaultProfile = $ps7Profile.guid
+            $updatedSettings = $settingsContent | ConvertTo-Json -Depth 100
+            Set-Content -Path $settingsPath -Value $updatedSettings
+            Write-Host "Default profile updated to $targetTerminalName using the name attribute."
+        } else {
+            Write-Host "No PowerShell 7 profile found in Windows Terminal settings using the name attribute."
+        }
+    } else {
+        Write-Host "Settings file not found at $settingsPath"
+    } 
+}
+


### PR DESCRIPTION
As promised, I've taken another look at the Code and realised, that the implementation of Install-WinUtilProgramWinget is a bit annoying because it expects a List containing an Object (or Dictionary) with the "winget" key containing the app id.
_I think this function has a lot of potential to be optimized in the future to work better and become easier to use_

Because the text conversion from the tweaks section with the containing text conversion proved to be a bit inflexible to work with, I opted (like for OOSU) to use a separate function for the logic and only reference the logic from the tweaks file. (In my opinnion this is also way easier to work with and maintain in the future, but this may also be just preference) 
I also added logic to undo the change if the user desired to. This required the use of the targetTerminalName instead of the targetTerminalSource which is not optimal, but I was a bit lazy to be fully honest and didn't want to modify the logic any more than necessary. 

I'd also re-add the winutil.ps1 and inputTweaks.xaml to reflect the last state in the Repo of Chris because like this, your PR will only show the files you actually changed and won't contain 10000+ deleted lines in the auto-generated files.

This is how I would implement the feature. If this is to your liking, just approve the PR and the PR in the official Repo should be automatically updated as well. If not, maybe this at least gives you an idea how to work with Install-WinUtilProgramWinget :D